### PR TITLE
fix: mentor list updated for astrartos

### DIFF
--- a/_projects/AstraRTOS.md
+++ b/_projects/AstraRTOS.md
@@ -9,7 +9,7 @@ importance: 3
 
 | Project Domains                                          | Mentors                       |
 |----------------------------------------------------------|-------------------------------|
-| Real-Time Operating Systems, Low Level Embedded Systems  | Vedant Malkar, Paarth Shirsat |
+| Real-Time Operating Systems, Low Level Embedded Systems  | Vedant Malkar, Paarth Shirsat, Mustafa |
 
 ---
 


### PR DESCRIPTION
The mentor list for the Eklavya project 'AstraRTOS' has been updated. The following changes are tested with the docker development environment.

Screenshots:
---
<img width="1536" height="773" alt="image" src="https://github.com/user-attachments/assets/3582002c-cd01-4668-8a04-c4cd240da445" />
